### PR TITLE
chore: add tiles tests

### DIFF
--- a/developpement_diary/2023-09-25.md
+++ b/developpement_diary/2023-09-25.md
@@ -1,0 +1,7 @@
+## 2023-09-25
+
+After trying to fix the centerMapOnPlayer() function that had stopped working for some unknown reason (see [PR #60](https://github.com/zwindler/gocastle/pull/60/files)), I discovered that fyne 2.4.0 was out and to my great surprise, it was fixing both #60 and #5.
+
+Sometimes, you just have to upgrade :upside_down_face:
+
+I also moved the tiles and maps files to their own package in pkg/

--- a/developpement_diary/2023-09-26.md
+++ b/developpement_diary/2023-09-26.md
@@ -1,0 +1,7 @@
+## 2023-09-26
+
+Yesterday I moved a lot of code around but today I realised that I left out a lot of tests and that it was not that difficult to add.
+
+So I made a big "testing PR" to improve coverage for various packages I had moved carelessly :-p
+
+See #66

--- a/pkg/maps/maps_logic.go
+++ b/pkg/maps/maps_logic.go
@@ -90,7 +90,7 @@ func (currentMap *Map) CheckTileIsSpecial(posX, posY int) SpecialTile {
 }
 
 // FindObjectToRemove loops through the currentMap ObjectList and removes object *model.Object.
-func (currentMap *Map) FindObjectToRemove(object *model.Object) {
+func (currentMap *Map) FindObjectToRemove(object *model.Object) error {
 	indexToRemove := -1
 	for i, obj := range currentMap.ObjectList {
 		if obj == object {
@@ -102,11 +102,14 @@ func (currentMap *Map) FindObjectToRemove(object *model.Object) {
 	// If the object was found, remove it from the slice
 	if indexToRemove >= 0 {
 		currentMap.ObjectList = append(currentMap.ObjectList[:indexToRemove], currentMap.ObjectList[indexToRemove+1:]...)
+		return nil
 	}
+
+	return fmt.Errorf("unable to find object to remove")
 }
 
 // For a given map, remove NPC by list id and hide CanvasImage.
-func (currentMap *Map) RemoveNPC(npcToRemove *model.NPCStats) {
+func (currentMap *Map) RemoveNPC(npcToRemove *model.NPCStats) error {
 	var indexToRemove int = -1
 	for i, npc := range currentMap.NPCList {
 		if npc == npcToRemove {
@@ -121,7 +124,10 @@ func (currentMap *Map) RemoveNPC(npcToRemove *model.NPCStats) {
 		currentMap.NPCList[indexToRemove].Avatar.CanvasImage.Hidden = true
 		// remove NPC from NPCList slice
 		currentMap.NPCList = append(currentMap.NPCList[:indexToRemove], currentMap.NPCList[indexToRemove+1:]...)
+		return nil
 	}
+
+	return fmt.Errorf("unable to find NPC to remove")
 }
 
 // For a given NPCsOnCurrentMap, check if NPCs are located on x,y

--- a/pkg/maps/maps_logic_test.go
+++ b/pkg/maps/maps_logic_test.go
@@ -1,0 +1,164 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/zwindler/gocastle/model"
+	"github.com/zwindler/gocastle/pkg/tiles"
+)
+
+var testMap = Map{
+	MapMatrix: [][]int{
+		{0, 0, 0},
+		{0, 13, 0}, // 13 is not walkable
+	},
+	MapTransitions: []SpecialTile{
+		{"MapTransition", model.Coord{X: 0, Y: 0, Map: 2}, model.Coord{X: 73, Y: 2, Map: 1}},
+	},
+}
+
+func TestGetMapSize(t *testing.T) {
+	rows, columns := testMap.GetMapSize()
+
+	if rows != 2 || columns != 3 {
+		t.Errorf("GetMapSize() = (%d, %d); want (2, 3)", rows, columns)
+	}
+}
+
+func TestGetMapImageSize(t *testing.T) {
+	sizeY, sizeX := testMap.GetMapImageSize()
+
+	if sizeX != float32(2*tiles.TileSize) || sizeY != float32(3*tiles.TileSize) {
+		t.Errorf("GetMapSize() = (%f, %f); want (64, 96)", sizeX, sizeY)
+	}
+}
+
+func TestCheckOutOfBounds(t *testing.T) {
+	tcs := []struct {
+		x, y     int
+		expected bool
+	}{
+		{0, 0, false},
+		{-1, 0, true},
+		{0, 2, true},
+		{4, 0, true},
+		{1, 1, false},
+	}
+
+	for _, tc := range tcs {
+		result := testMap.CheckOutOfBounds(tc.x, tc.y)
+		if result != tc.expected {
+			t.Errorf("CheckOutOfBounds(%d, %d) = %v; want %v", tc.x, tc.y, result, tc.expected)
+		}
+	}
+}
+
+func TestCheckTileIsWalkable(t *testing.T) {
+	tcs := []struct {
+		x, y     int
+		expected bool
+	}{
+		{1, 1, false},
+		{0, 0, true},
+	}
+
+	for _, tc := range tcs {
+		result := testMap.CheckTileIsWalkable(tc.x, tc.y)
+		if result != tc.expected {
+			t.Errorf("CheckTileIsWalkable(%d, %d) = %v; want %v", tc.x, tc.y, result, tc.expected)
+		}
+	}
+}
+
+func TestCheckTileIsSpecial(t *testing.T) {
+	tcs := []struct {
+		x, y     int
+		expected SpecialTile
+	}{
+		{1, 1, NotSpecialTile},
+		{0, 0, testMap.MapTransitions[0]},
+	}
+
+	for _, tc := range tcs {
+		result := testMap.CheckTileIsSpecial(tc.x, tc.y)
+		if result != tc.expected {
+			t.Errorf("CheckTileIsSpecial(%d, %d) = %v; want %v", tc.x, tc.y, result, tc.expected)
+		}
+	}
+}
+
+func TestFindObjectToRemove(t *testing.T) {
+	knife, _ := model.CreateObject(model.HuntingKnife, model.Coord{X: 0, Y: 0, Map: 0})
+	sword, _ := model.CreateObject(model.BluntSword, model.Coord{X: 1, Y: 1, Map: 0})
+
+	// add a sword and a knife on the map
+	testMap.ObjectList = append(testMap.ObjectList, &knife, &sword)
+
+	// remove the knife from the map
+	err := testMap.FindObjectToRemove(&knife)
+	if err != nil {
+		t.Errorf("failed to remove knife: %s", err)
+	}
+
+	// remove the knife from the map again
+	err = testMap.FindObjectToRemove(&knife)
+	if err == nil {
+		t.Errorf("function FindObjectToRemove removed a knife and shouldn't have")
+	}
+}
+
+func TestRemoveNPC(t *testing.T) {
+	wolf1 := model.CreateNPC(model.Wolf, model.Coord{X: 0, Y: 1, Map: 0})
+
+	// add a wolf on the map
+	testMap.NPCList = append(testMap.NPCList, wolf1)
+
+	// remove the wolf from the map
+	err := testMap.RemoveNPC(wolf1)
+	if err != nil {
+		t.Errorf("failed to remove wolf: %s", err)
+	}
+
+	// remove the wolf from the map again
+	err = testMap.RemoveNPC(wolf1)
+	if err == nil {
+		t.Errorf("function RemoveNPC removed a wolf and shouldn't have")
+	}
+}
+
+func TestGetNPCAtPosition(t *testing.T) {
+	wolf1 := model.CreateNPC(model.Wolf, model.Coord{X: 0, Y: 1, Map: 0})
+
+	// add a wolf on the map
+	testMap.NPCList = append(testMap.NPCList, wolf1)
+
+	// Test case 1: NPC exists at the specified position
+	npc1 := testMap.GetNPCAtPosition(0, 1)
+	if npc1 == nil {
+		t.Error("Expected NPC to exist at (0, 1), but it was not found.")
+	}
+
+	// Test case 2: NPC does not exist at the specified position
+	npc2 := testMap.GetNPCAtPosition(5, 5)
+	if npc2 != nil {
+		t.Error("Expected no NPC at (5, 5), but one was found.")
+	}
+}
+
+func TestGenerateMapImage(t *testing.T) {
+	testMap.GenerateMapImage()
+
+	if testMap.MapImage == nil {
+		t.Error("Expected a non-nil map image, but it was nil.")
+	}
+
+	expectedWidth := float32(len(testMap.MapMatrix[0]) * tiles.TileSize)
+	expectedHeight := float32(len(testMap.MapMatrix) * tiles.TileSize)
+
+	imgWidth := float32(testMap.MapImage.Bounds().Dx())
+	imgHeight := float32(testMap.MapImage.Bounds().Dy())
+
+	if imgWidth != expectedWidth || imgHeight != expectedHeight {
+		t.Errorf("Expected map image dimensions (%.2f, %.2f), but got (%.2f, %.2f).", expectedWidth, expectedHeight, imgWidth, imgHeight)
+	}
+}

--- a/pkg/newtheme/theme_test.go
+++ b/pkg/newtheme/theme_test.go
@@ -1,0 +1,18 @@
+package newtheme
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/theme"
+)
+
+func TestCustomTheme_Size_WithCustomValues(t *testing.T) {
+	customTheme := CustomTheme{}
+	sizeName := theme.SizeNameInnerPadding
+
+	resultSize := customTheme.Size(sizeName)
+
+	if resultSize != float32(8) {
+		t.Errorf("CustomTheme.Size(%v) returned %v, expected %v", sizeName, resultSize, float32(8))
+	}
+}

--- a/pkg/tiles/tiles_test.go
+++ b/pkg/tiles/tiles_test.go
@@ -1,0 +1,49 @@
+package tiles
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLoadTilesFromTileset(t *testing.T) {
+	testTiles := []TileInfo{
+		{X: 0, Y: 0, filePath: "static/tilea2_MACK.png", IsWalkable: true},
+		{X: 192, Y: 0, filePath: "static/tilea3_MACK.png", IsWalkable: false},
+	}
+
+	// Call the LoadTilesFromTileset function
+	images, err := LoadTilesFromTileset(testTiles)
+	if err != nil {
+		t.Errorf("LoadTilesFromTileset returned an error: %v", err)
+	}
+
+	// Verify that the number of loaded images matches the number of testTiles
+	if len(images) != len(testTiles) {
+		t.Errorf("Expected %d images, but got %d", len(testTiles), len(images))
+	}
+}
+
+func TestExtractTileFromTileset(t *testing.T) {
+	testCases := []struct {
+		x        int
+		y        int
+		filePath string
+	}{
+		{x: 0, y: 0, filePath: "static/tilea2_MACK.png"},
+		{x: 192, y: 0, filePath: "static/tilea3_MACK.png"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("x=%d_y=%d", tc.x, tc.y), func(t *testing.T) {
+			image, err := extractTileFromTileset(tc.x, tc.y, tc.filePath)
+			if err != nil {
+				t.Errorf("extractTileFromTileset returned an error: %v", err)
+			}
+
+			// Verify that the loaded image is not nil
+			if image == nil {
+				t.Error("extractTileFromTileset returned a nil image")
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #64 

* added error handling for some functions in pkg/maps
* added tests to 
  * maps (0% to 94,8%)
  * tiles (0% to 76,2%)
  * newtheme (0 to 25%)

```
?       github.com/zwindler/gocastle    [no test files]
?       github.com/zwindler/gocastle/model      [no test files]
?       github.com/zwindler/gocastle/pkg/avatar [no test files]
?       github.com/zwindler/gocastle/pkg/coord  [no test files]
ok      github.com/zwindler/gocastle/pkg/embed  0.011s  coverage: 80.0% of statements
?       github.com/zwindler/gocastle/pkg/npc    [no test files]
ok      github.com/zwindler/gocastle/pkg/hp     0.004s  coverage: 95.0% of statements
?       github.com/zwindler/gocastle/pkg/utils  [no test files]
?       github.com/zwindler/gocastle/screens    [no test files]
ok      github.com/zwindler/gocastle/pkg/maps   0.433s  coverage: 94.8% of statements
ok      github.com/zwindler/gocastle/pkg/mp     0.003s  coverage: 100.0% of statements
ok      github.com/zwindler/gocastle/pkg/newtheme       0.005s  coverage: 25.0% of statements
ok      github.com/zwindler/gocastle/pkg/pts    0.003s  coverage: 100.0% of statements
ok      github.com/zwindler/gocastle/pkg/tiles  0.047s  coverage: 76.2% of statements
ok      github.com/zwindler/gocastle/pkg/timespent 
```